### PR TITLE
CalcSigHash wrapper function

### DIFF
--- a/blockchain/cost.go
+++ b/blockchain/cost.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/roasbeef/btcd/txscript"
+	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
 )
 
@@ -49,6 +50,11 @@ func GetTxVirtualSize(tx *btcutil.Tx) int64 {
 		WitnessScaleFactor
 }
 
+// GetMsgTxVirtualSize is the same as GetTxVirtualSize but doesn't use btcutil.Tx
+func GetMsgTxVirtualSize(tx *wire.MsgTx) int64 {
+	return (GetMsgTxCost(tx) + (WitnessScaleFactor - 1)) / WitnessScaleFactor
+}
+
 // GetBlockCost computes the value of the cost metric for a given block.
 // Currently the cost metric is simply the sum of the block's serialized size
 // without any witness data scaled proportionally by the WitnessScaleFactor,
@@ -74,6 +80,14 @@ func GetTransactionCost(tx *btcutil.Tx) int64 {
 	baseSize := msgTx.SerializeSizeStripped()
 	totalSize := msgTx.SerializeSize()
 
+	// (baseSize * 3) + totalSize
+	return int64((baseSize * (WitnessScaleFactor - 1)) + totalSize)
+}
+
+// GetMsgTxCost is the same as GetTransactionCost but doesn't use btctil.Tx
+func GetMsgTxCost(tx *wire.MsgTx) int64 {
+	baseSize := tx.SerializeSizeStripped()
+	totalSize := tx.SerializeSize()
 	// (baseSize * 3) + totalSize
 	return int64((baseSize * (WitnessScaleFactor - 1)) + totalSize)
 }

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -268,9 +268,11 @@ var TestNet3Params = Params{
 	RelayNonStdTxs: true,
 
 	// Address encoding magics
-	PubKeyHashAddrID: 0x6f, // starts with m or n
-	ScriptHashAddrID: 0xc4, // starts with 2
-	PrivateKeyID:     0xef, // starts with 9 (uncompressed) or c (compressed)
+	PubKeyHashAddrID:        0x6f, // starts with m or n
+	ScriptHashAddrID:        0xc4, // starts with 2
+	WitnessPubKeyHashAddrID: 0x77, // starts with H5
+	WitnessScriptHashAddrID: 0x79, // starts with ?
+	PrivateKeyID:            0xef, // starts with 9 (uncompressed) or c (compressed)
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -12,10 +12,10 @@ import (
 	"fmt"
 	"hash"
 
-	"github.com/roasbeef/btcd/btcec"
-	"github.com/roasbeef/btcd/wire"
 	"github.com/btcsuite/fastsha256"
 	"github.com/btcsuite/golangcrypto/ripemd160"
+	"github.com/roasbeef/btcd/btcec"
+	"github.com/roasbeef/btcd/wire"
 )
 
 // An opcode defines the information related to a txscript opcode.  opfunc, if
@@ -215,6 +215,7 @@ const (
 	OP_NOP2                = 0xb1 // 177
 	OP_CHECKLOCKTIMEVERIFY = 0xb1 // 177 - AKA OP_NOP2
 	OP_NOP3                = 0xb2 // 178
+	OP_CHECKSEQUENCEVERIFY = 0xb2 // 178 - AKA OP_NOP3
 	OP_NOP4                = 0xb3 // 179
 	OP_NOP5                = 0xb4 // 180
 	OP_NOP6                = 0xb5 // 181

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -876,7 +876,7 @@ func opcodeN(op *parsedOpcode, vm *Engine) error {
 // the flag to discourage use of NOPs is set for select opcodes.
 func opcodeNop(op *parsedOpcode, vm *Engine) error {
 	switch op.opcode.value {
-	case OP_NOP1, OP_NOP3, OP_NOP4, OP_NOP5,
+	case OP_NOP1, OP_NOP4, OP_NOP5,
 		OP_NOP6, OP_NOP7, OP_NOP8, OP_NOP9, OP_NOP10:
 		if vm.hasFlag(ScriptDiscourageUpgradableNops) {
 			return fmt.Errorf("OP_NOP%d reserved for soft-fork "+

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -399,6 +399,19 @@ func calcHashOutputs(tx *wire.MsgTx) wire.ShaHash {
 	return wire.DoubleSha256SH(b.Bytes())
 }
 
+// CalcWitnessSigHash exports calcWitnessSignatureHash so that signatures
+// can be verified.
+func CalcWitnessSigHash(subScript []byte, sigHashes *TxSigHashes,
+	hashType SigHashType, tx *wire.MsgTx, idx int, amt int64) ([]byte, error) {
+	parsedScript, err := parseScript(subScript)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse output script: %v", err)
+	}
+	sighash := calcWitnessSignatureHash(
+		parsedScript, sigHashes, hashType, tx, idx, amt)
+	return sighash, nil
+}
+
 // calcWitnessSignatureHash computes the sighash digest of a transaction's
 // segwit input using the new, optimized digest calculation algorithm defined
 // in BIP0143: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki.

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// TxVersion is the current latest supported transaction version.
-	TxVersion = 1
+	TxVersion = 2
 
 	// MaxTxInSequenceNum is the maximum sequence number the sequence field
 	// of a transaction input can be.


### PR DESCRIPTION
includes parseScript so that doesn't need to be exported.
Duplicate vsize functions in blockchain/cost.go.  Kindof ugly; it'd be nicer to have VirtualSize() be a method on the util tx, but that would need a bit of ra-arranging to fix an import cycle.