### PR TITLE
rpcserver: allow limited user access to `getblockheader` command

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -268,6 +268,7 @@ var rpcLimited = map[string]struct{}{
 	"getblock":              {},
 	"getblockcount":         {},
 	"getblockhash":          {},
+	"getblockheader":        {},
 	"getcurrentnet":         {},
 	"getdifficulty":         {},
 	"getinfo":               {},


### PR DESCRIPTION
This PR allows the limited user to access the `getblockheader` RPC command. This is used in `lnd`'s `getinfo` RPC command, which currently doesn't work when running `lnd` with the limited `btcd` RPC user.