### PR TITLE
Fix `getcfilter` and `getcfilterheader` RPC commands

### DIFF
--- a/btcjson/jsonrpcerr.go
+++ b/btcjson/jsonrpcerr.go
@@ -71,6 +71,7 @@ const (
 	ErrRPCDifficulty        RPCErrorCode = -5
 	ErrRPCOutOfRange        RPCErrorCode = -1
 	ErrRPCNoTxInfo          RPCErrorCode = -5
+	ErrRPCNoCFIndex         RPCErrorCode = -5
 	ErrRPCNoNewestBlockInfo RPCErrorCode = -5
 	ErrRPCInvalidTxVout     RPCErrorCode = -5
 	ErrRPCRawTxString       RPCErrorCode = -32602

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2142,6 +2142,13 @@ func handleGetBlockTemplate(s *rpcServer, cmd interface{}, closeChan <-chan stru
 
 // handleGetCFilter implements the getcfilter command.
 func handleGetCFilter(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	if s.cfg.CfIndex == nil {
+		return nil, &btcjson.RPCError{
+			Code:    btcjson.ErrRPCNoCFIndex,
+			Message: "The CF index must be enabled for this command",
+		}
+	}
+
 	c := cmd.(*btcjson.GetCFilterCmd)
 	hash, err := chainhash.NewHashFromStr(c.Hash)
 	if err != nil {
@@ -2164,6 +2171,13 @@ func handleGetCFilter(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 
 // handleGetCFilterHeader implements the getcfilterheader command.
 func handleGetCFilterHeader(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	if s.cfg.CfIndex == nil {
+		return nil, &btcjson.RPCError{
+			Code:    btcjson.ErrRPCNoCFIndex,
+			Message: "The CF index must be enabled for this command",
+		}
+	}
+
 	c := cmd.(*btcjson.GetCFilterHeaderCmd)
 	hash, err := chainhash.NewHashFromStr(c.Hash)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -2656,6 +2656,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			CPUMiner:    s.cpuMiner,
 			TxIndex:     s.txIndex,
 			AddrIndex:   s.addrIndex,
+			CfIndex:     s.cfIndex,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR ensures that the RPC server's `CfIndex` pointer gets initialized, and cleans up error handling in the case of `--nocfilters` being enabled.