### PR TITLE
Update for BIP compliance

### DIFF
--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -222,7 +222,7 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 	}
 
 	f, err = builder.BuildExtFilter(block.MsgBlock())
-	if err != nil {
+	if err != nil && err != gcs.ErrNoData {
 		return err
 	}
 

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -7,6 +7,7 @@ package indexers
 import (
 	"errors"
 
+	"github.com/btcsuite/fastsha256"
 	"github.com/roasbeef/btcd/blockchain"
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
@@ -14,7 +15,6 @@ import (
 	"github.com/roasbeef/btcutil"
 	"github.com/roasbeef/btcutil/gcs"
 	"github.com/roasbeef/btcutil/gcs/builder"
-	"github.com/btcsuite/fastsha256"
 )
 
 const (
@@ -30,21 +30,21 @@ var (
 	// the index. The rest of the buckets live below this bucket.
 	cfIndexParentBucketKey = []byte("cfindexparentbucket")
 
-	// cfBasicIndexKey is the name of the db bucket used to house the
-	// block hash -> basic cf index (cf#0).
-	cfBasicIndexKey = []byte("cf0byhashidx")
+	// cfIndexKeys is an array of db bucket names used to house indexes of
+	// block hashes to cfilters.
+	cfIndexKeys = [][]byte{
+		[]byte("cf0byhashidx"),
+		[]byte("cf1byhashidx"),
+	}
 
-	// cfBasicHeaderKey is the name of the db bucket used to house the
-	// block hash -> basic cf header index (cf#0).
-	cfBasicHeaderKey = []byte("cf0headerbyhashidx")
+	// cfHeaderKeys is an array of db bucket names used to house indexes of
+	// block hashes to cf headers.
+	cfHeaderKeys = [][]byte{
+		[]byte("cf0headerbyhashidx"),
+		[]byte("cf1headerbyhashidx"),
+	}
 
-	// cfExtendedIndexKey is the name of the db bucket used to house the
-	// block hash -> extended cf index (cf#1).
-	cfExtendedIndexKey = []byte("cf1byhashidx")
-
-	// cfExtendedHeaderKey is the name of the db bucket used to house the
-	// block hash -> extended cf header index (cf#1).
-	cfExtendedHeaderKey = []byte("cf1headerbyhashidx")
+	maxFilterType = uint8(len(cfHeaderKeys) - 1)
 )
 
 // dbFetchFilter retrieves a block's basic or extended filter. A filter's
@@ -131,27 +131,25 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 	if err != nil {
 		return err
 	}
-	_, err = cfIndexParentBucket.CreateBucket(cfBasicIndexKey)
-	if err != nil {
-		return err
+
+	for _, bucketName := range cfIndexKeys {
+		_, err = cfIndexParentBucket.CreateBucket(bucketName)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = cfIndexParentBucket.CreateBucket(cfBasicHeaderKey)
-	if err != nil {
-		return err
-	}
-	_, err = cfIndexParentBucket.CreateBucket(cfExtendedIndexKey)
-	if err != nil {
-		return err
-	}
-	_, err = cfIndexParentBucket.CreateBucket(cfExtendedHeaderKey)
-	if err != nil {
-		return err
+
+	for _, bucketName := range cfHeaderKeys {
+		_, err = cfIndexParentBucket.CreateBucket(bucketName)
+		if err != nil {
+			return err
+		}
 	}
 
 	firstHeader := make([]byte, chainhash.HashSize)
 	err = dbStoreFilterHeader(
 		dbTx,
-		cfBasicHeaderKey,
+		cfHeaderKeys[0],
 		&idx.chainParams.GenesisBlock.Header.PrevBlock,
 		firstHeader,
 	)
@@ -161,7 +159,7 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 
 	return dbStoreFilterHeader(
 		dbTx,
-		cfExtendedHeaderKey,
+		cfHeaderKeys[1],
 		&idx.chainParams.GenesisBlock.Header.PrevBlock,
 		firstHeader,
 	)
@@ -170,15 +168,14 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 // storeFilter stores a given filter, and performs the steps needed to
 // generate the filter's header.
 func storeFilter(dbTx database.Tx, block *btcutil.Block, f *gcs.Filter,
-	extended bool) error {
+	filterType uint8) error {
+	if filterType > maxFilterType {
+		return errors.New("unsupported filter type")
+	}
 
 	// Figure out which buckets to use.
-	fkey := cfBasicIndexKey
-	hkey := cfBasicHeaderKey
-	if extended {
-		fkey = cfExtendedIndexKey
-		hkey = cfExtendedHeaderKey
-	}
+	fkey := cfIndexKeys[filterType]
+	hkey := cfHeaderKeys[filterType]
 
 	// Start by storing the filter.
 	h := block.Hash()
@@ -218,7 +215,7 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 		return err
 	}
 
-	if err := storeFilter(dbTx, block, f, false); err != nil {
+	if err := storeFilter(dbTx, block, f, 0); err != nil {
 		return err
 	}
 
@@ -227,7 +224,7 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 		return err
 	}
 
-	return storeFilter(dbTx, block, f, true)
+	return storeFilter(dbTx, block, f, 1)
 }
 
 // DisconnectBlock is invoked by the index manager when a block has been
@@ -236,26 +233,34 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 func (idx *CfIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 	view *blockchain.UtxoViewpoint) error {
 
-	err := dbDeleteFilter(dbTx, cfBasicIndexKey, block.Hash())
-	if err != nil {
-		return err
+	for _, key := range cfIndexKeys {
+		err := dbDeleteFilter(dbTx, key, block.Hash())
+		if err != nil {
+			return err
+		}
 	}
 
-	return dbDeleteFilter(dbTx, cfExtendedIndexKey, block.Hash())
+	for _, key := range cfHeaderKeys {
+		err := dbDeleteFilterHeader(dbTx, key, block.Hash())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // FilterByBlockHash returns the serialized contents of a block's basic or
 // extended committed filter.
-func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash, extended bool) ([]byte, error) {
+func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash, filterType uint8) ([]byte, error) {
 	var f []byte
 	err := idx.db.View(func(dbTx database.Tx) error {
-		var err error
-		key := cfBasicIndexKey
-		if extended {
-			key = cfExtendedIndexKey
+		if filterType > maxFilterType {
+			return errors.New("unsupported filter type")
 		}
 
-		f, err = dbFetchFilter(dbTx, key, h)
+		var err error
+		f, err = dbFetchFilter(dbTx, cfIndexKeys[filterType], h)
 		return err
 	})
 	return f, err
@@ -263,16 +268,15 @@ func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash, extended bool) ([]byte,
 
 // FilterHeaderByBlockHash returns the serialized contents of a block's basic
 // or extended committed filter header.
-func (idx *CfIndex) FilterHeaderByBlockHash(h *chainhash.Hash, extended bool) ([]byte, error) {
+func (idx *CfIndex) FilterHeaderByBlockHash(h *chainhash.Hash, filterType uint8) ([]byte, error) {
 	var fh []byte
 	err := idx.db.View(func(dbTx database.Tx) error {
-		var err error
-		key := cfBasicHeaderKey
-		if extended {
-			key = cfExtendedHeaderKey
+		if filterType > 1 {
+			return errors.New("unsupported filter type")
 		}
 
-		fh, err = dbFetchFilterHeader(dbTx, key, h)
+		var err error
+		fh, err = dbFetchFilterHeader(dbTx, cfHeaderKeys[filterType], h)
 		return err
 	})
 	return fh, err

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -12,6 +12,7 @@ import (
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/database"
+	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
 	"github.com/roasbeef/btcutil/gcs"
 	"github.com/roasbeef/btcutil/gcs/builder"
@@ -149,7 +150,7 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 	firstHeader := make([]byte, chainhash.HashSize)
 	err = dbStoreFilterHeader(
 		dbTx,
-		cfHeaderKeys[0],
+		cfHeaderKeys[wire.GCSFilterRegular],
 		&idx.chainParams.GenesisBlock.Header.PrevBlock,
 		firstHeader,
 	)
@@ -159,7 +160,7 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 
 	return dbStoreFilterHeader(
 		dbTx,
-		cfHeaderKeys[1],
+		cfHeaderKeys[wire.GCSFilterExtended],
 		&idx.chainParams.GenesisBlock.Header.PrevBlock,
 		firstHeader,
 	)
@@ -168,8 +169,8 @@ func (idx *CfIndex) Create(dbTx database.Tx) error {
 // storeFilter stores a given filter, and performs the steps needed to
 // generate the filter's header.
 func storeFilter(dbTx database.Tx, block *btcutil.Block, f *gcs.Filter,
-	filterType uint8) error {
-	if filterType > maxFilterType {
+	filterType wire.FilterType) error {
+	if uint8(filterType) > maxFilterType {
 		return errors.New("unsupported filter type")
 	}
 
@@ -215,7 +216,8 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 		return err
 	}
 
-	if err := storeFilter(dbTx, block, f, 0); err != nil {
+	if err := storeFilter(dbTx, block, f,
+		wire.GCSFilterRegular); err != nil {
 		return err
 	}
 
@@ -224,7 +226,7 @@ func (idx *CfIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
 		return err
 	}
 
-	return storeFilter(dbTx, block, f, 1)
+	return storeFilter(dbTx, block, f, wire.GCSFilterExtended)
 }
 
 // DisconnectBlock is invoked by the index manager when a block has been
@@ -252,10 +254,11 @@ func (idx *CfIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 
 // FilterByBlockHash returns the serialized contents of a block's basic or
 // extended committed filter.
-func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash, filterType uint8) ([]byte, error) {
+func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash,
+	filterType wire.FilterType) ([]byte, error) {
 	var f []byte
 	err := idx.db.View(func(dbTx database.Tx) error {
-		if filterType > maxFilterType {
+		if uint8(filterType) > maxFilterType {
 			return errors.New("unsupported filter type")
 		}
 
@@ -268,15 +271,17 @@ func (idx *CfIndex) FilterByBlockHash(h *chainhash.Hash, filterType uint8) ([]by
 
 // FilterHeaderByBlockHash returns the serialized contents of a block's basic
 // or extended committed filter header.
-func (idx *CfIndex) FilterHeaderByBlockHash(h *chainhash.Hash, filterType uint8) ([]byte, error) {
+func (idx *CfIndex) FilterHeaderByBlockHash(h *chainhash.Hash,
+	filterType wire.FilterType) ([]byte, error) {
 	var fh []byte
 	err := idx.db.View(func(dbTx database.Tx) error {
-		if filterType > 1 {
+		if uint8(filterType) > maxFilterType {
 			return errors.New("unsupported filter type")
 		}
 
 		var err error
-		fh, err = dbFetchFilterHeader(dbTx, cfHeaderKeys[filterType], h)
+		fh, err = dbFetchFilterHeader(dbTx,
+			cfHeaderKeys[filterType], h)
 		return err
 	})
 	return fh, err

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -10,6 +10,8 @@ package btcjson
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/roasbeef/btcd/wire"
 )
 
 // AddNodeSubCmd defines the type used in the addnode JSON-RPC command for the
@@ -282,12 +284,12 @@ func NewGetBlockTemplateCmd(request *TemplateRequest) *GetBlockTemplateCmd {
 // GetCFilterCmd defines the getcfilter JSON-RPC command.
 type GetCFilterCmd struct {
 	Hash       string
-	FilterType uint8
+	FilterType wire.FilterType
 }
 
 // NewGetCFilterCmd returns a new instance which can be used to issue a
 // getcfilter JSON-RPC command.
-func NewGetCFilterCmd(hash string, filterType uint8) *GetCFilterCmd {
+func NewGetCFilterCmd(hash string, filterType wire.FilterType) *GetCFilterCmd {
 	return &GetCFilterCmd{
 		Hash:       hash,
 		FilterType: filterType,
@@ -297,12 +299,13 @@ func NewGetCFilterCmd(hash string, filterType uint8) *GetCFilterCmd {
 // GetCFilterHeaderCmd defines the getcfilterheader JSON-RPC command.
 type GetCFilterHeaderCmd struct {
 	Hash       string
-	FilterType uint8
+	FilterType wire.FilterType
 }
 
 // NewGetCFilterHeaderCmd returns a new instance which can be used to issue a
 // getcfilterheader JSON-RPC command.
-func NewGetCFilterHeaderCmd(hash string, filterType uint8) *GetCFilterHeaderCmd {
+func NewGetCFilterHeaderCmd(hash string,
+	filterType wire.FilterType) *GetCFilterHeaderCmd {
 	return &GetCFilterHeaderCmd{
 		Hash:       hash,
 		FilterType: filterType,

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -278,33 +278,34 @@ func NewGetBlockTemplateCmd(request *TemplateRequest) *GetBlockTemplateCmd {
 		Request: request,
 	}
 }
+
 // GetCFilterCmd defines the getcfilter JSON-RPC command.
 type GetCFilterCmd struct {
-	Hash     string
-	Extended bool
+	Hash       string
+	FilterType uint8
 }
 
 // NewGetCFilterCmd returns a new instance which can be used to issue a
 // getcfilter JSON-RPC command.
-func NewGetCFilterCmd(hash string, extended bool) *GetCFilterCmd {
+func NewGetCFilterCmd(hash string, filterType uint8) *GetCFilterCmd {
 	return &GetCFilterCmd{
-		Hash:     hash,
-		Extended: extended,
+		Hash:       hash,
+		FilterType: filterType,
 	}
 }
 
 // GetCFilterHeaderCmd defines the getcfilterheader JSON-RPC command.
 type GetCFilterHeaderCmd struct {
-	Hash     string
-	Extended bool
+	Hash       string
+	FilterType uint8
 }
 
 // NewGetCFilterHeaderCmd returns a new instance which can be used to issue a
 // getcfilterheader JSON-RPC command.
-func NewGetCFilterHeaderCmd(hash string, extended bool) *GetCFilterHeaderCmd {
+func NewGetCFilterHeaderCmd(hash string, filterType uint8) *GetCFilterHeaderCmd {
 	return &GetCFilterHeaderCmd{
-		Hash:     hash,
-		Extended: extended,
+		Hash:       hash,
+		FilterType: filterType,
 	}
 }
 

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -320,27 +320,27 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getcfilter",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getcfilter", "123", false)
+				return btcjson.NewCmd("getcfilter", "123", 0)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetCFilterCmd("123", false)
+				return btcjson.NewGetCFilterCmd("123", 0)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getcfilter","params":["123",false],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterCmd{
-				Hash:    "123",
+				Hash: "123",
 			},
 		},
 		{
 			name: "getcfilterheader",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getcfilterheader", "123", false)
+				return btcjson.NewCmd("getcfilterheader", "123", 0)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetCFilterHeaderCmd("123", false)
+				return btcjson.NewGetCFilterHeaderCmd("123", 0)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getcfilterheader","params":["123",false],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterHeaderCmd{
-				Hash:    "123",
+				Hash: "123",
 			},
 		},
 		{

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -325,7 +325,7 @@ func TestChainSvrCmds(t *testing.T) {
 			staticCmd: func() interface{} {
 				return btcjson.NewGetCFilterCmd("123", 0)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getcfilter","params":["123",false],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getcfilter","params":["123",0],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterCmd{
 				Hash: "123",
 			},
@@ -338,7 +338,7 @@ func TestChainSvrCmds(t *testing.T) {
 			staticCmd: func() interface{} {
 				return btcjson.NewGetCFilterHeaderCmd("123", 0)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getcfilterheader","params":["123",false],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getcfilterheader","params":["123",0],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterHeaderCmd{
 				Hash: "123",
 			},

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/roasbeef/btcd/btcjson"
+	"github.com/roasbeef/btcd/wire"
 )
 
 // TestChainSvrCmds tests all of the chain server commands marshal and unmarshal
@@ -320,27 +321,33 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getcfilter",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getcfilter", "123", 0)
+				return btcjson.NewCmd("getcfilter", "123",
+					wire.GCSFilterExtended)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetCFilterCmd("123", 0)
+				return btcjson.NewGetCFilterCmd("123",
+					wire.GCSFilterExtended)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getcfilter","params":["123",0],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getcfilter","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterCmd{
-				Hash: "123",
+				Hash:       "123",
+				FilterType: wire.GCSFilterExtended,
 			},
 		},
 		{
 			name: "getcfilterheader",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getcfilterheader", "123", 0)
+				return btcjson.NewCmd("getcfilterheader", "123",
+					wire.GCSFilterExtended)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetCFilterHeaderCmd("123", 0)
+				return btcjson.NewGetCFilterHeaderCmd("123",
+					wire.GCSFilterExtended)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getcfilterheader","params":["123",0],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getcfilterheader","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetCFilterHeaderCmd{
-				Hash: "123",
+				Hash:       "123",
+				FilterType: wire.GCSFilterExtended,
 			},
 		},
 		{

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -126,9 +126,12 @@ type MessageListeners struct {
 	// OnCFilter is invoked when a peer receives a cfilter bitcoin message.
 	OnCFilter func(p *Peer, msg *wire.MsgCFilter)
 
-	// OnCFHeaders is invoked when a peer receives a cfheader bitcoin
+	// OnCFHeaders is invoked when a peer receives a cfheaders bitcoin
 	// message.
 	OnCFHeaders func(p *Peer, msg *wire.MsgCFHeaders)
+
+	// OnCFTypes is invoked when a peer receives a cftypes bitcoin message.
+	OnCFTypes func(p *Peer, msg *wire.MsgCFTypes)
 
 	// OnInv is invoked when a peer receives an inv bitcoin message.
 	OnInv func(p *Peer, msg *wire.MsgInv)
@@ -155,9 +158,13 @@ type MessageListeners struct {
 	// message.
 	OnGetCFilter func(p *Peer, msg *wire.MsgGetCFilter)
 
-	// OnGetCFHeaders is invoked when a peer receives a getcfheader
+	// OnGetCFHeaders is invoked when a peer receives a getcfheaders
 	// bitcoin message.
 	OnGetCFHeaders func(p *Peer, msg *wire.MsgGetCFHeaders)
+
+	// OnGetCFTypes is invoked when a peer receives a getcftypes bitcoin
+	// message.
+	OnGetCFTypes func(p *Peer, msg *wire.MsgGetCFTypes)
 
 	// OnFeeFilter is invoked when a peer receives a feefilter bitcoin message.
 	OnFeeFilter func(p *Peer, msg *wire.MsgFeeFilter)
@@ -1601,6 +1608,11 @@ out:
 				p.cfg.Listeners.OnGetCFHeaders(p, msg)
 			}
 
+		case *wire.MsgGetCFTypes:
+			if p.cfg.Listeners.OnGetCFTypes != nil {
+				p.cfg.Listeners.OnGetCFTypes(p, msg)
+			}
+
 		case *wire.MsgCFilter:
 			if p.cfg.Listeners.OnCFilter != nil {
 				p.cfg.Listeners.OnCFilter(p, msg)
@@ -1609,6 +1621,11 @@ out:
 		case *wire.MsgCFHeaders:
 			if p.cfg.Listeners.OnCFHeaders != nil {
 				p.cfg.Listeners.OnCFHeaders(p, msg)
+			}
+
+		case *wire.MsgCFTypes:
+			if p.cfg.Listeners.OnCFTypes != nil {
+				p.cfg.Listeners.OnCFTypes(p, msg)
 			}
 
 		case *wire.MsgFeeFilter:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/go-socks/socks"
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/peer"
 	"github.com/roasbeef/btcd/wire"
-	"github.com/btcsuite/go-socks/socks"
 )
 
 // conn mocks a network connection by implementing the net.Conn interface.  It
@@ -536,7 +536,7 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnGetCFilter",
-			wire.NewMsgGetCFilter(&chainhash.Hash{}, false),
+			wire.NewMsgGetCFilter(&chainhash.Hash{}, 0),
 		},
 		{
 			"OnGetCFHeaders",
@@ -544,7 +544,7 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnCFilter",
-			wire.NewMsgCFilter(&chainhash.Hash{}, true,
+			wire.NewMsgCFilter(&chainhash.Hash{}, 1,
 				[]byte("payload")),
 		},
 		{

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -405,10 +405,16 @@ func TestPeerListeners(t *testing.T) {
 			OnGetCFHeaders: func(p *peer.Peer, msg *wire.MsgGetCFHeaders) {
 				ok <- msg
 			},
+			OnGetCFTypes: func(p *peer.Peer, msg *wire.MsgGetCFTypes) {
+				ok <- msg
+			},
 			OnCFilter: func(p *peer.Peer, msg *wire.MsgCFilter) {
 				ok <- msg
 			},
 			OnCFHeaders: func(p *peer.Peer, msg *wire.MsgCFHeaders) {
+				ok <- msg
+			},
+			OnCFTypes: func(p *peer.Peer, msg *wire.MsgCFTypes) {
 				ok <- msg
 			},
 			OnFeeFilter: func(p *peer.Peer, msg *wire.MsgFeeFilter) {
@@ -543,6 +549,10 @@ func TestPeerListeners(t *testing.T) {
 			wire.NewMsgGetCFHeaders(),
 		},
 		{
+			"OnGetCFTypes",
+			wire.NewMsgGetCFTypes(),
+		},
+		{
 			"OnCFilter",
 			wire.NewMsgCFilter(&chainhash.Hash{}, 1,
 				[]byte("payload")),
@@ -550,6 +560,10 @@ func TestPeerListeners(t *testing.T) {
 		{
 			"OnCFHeaders",
 			wire.NewMsgCFHeaders(),
+		},
+		{
+			"OnCFTypes",
+			wire.NewMsgCFTypes([]uint8{0, 1}),
 		},
 		{
 			"OnFeeFilter",

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -542,7 +542,8 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnGetCFilter",
-			wire.NewMsgGetCFilter(&chainhash.Hash{}, 0),
+			wire.NewMsgGetCFilter(&chainhash.Hash{},
+				wire.GCSFilterRegular),
 		},
 		{
 			"OnGetCFHeaders",
@@ -554,8 +555,8 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnCFilter",
-			wire.NewMsgCFilter(&chainhash.Hash{}, 1,
-				[]byte("payload")),
+			wire.NewMsgCFilter(&chainhash.Hash{},
+				wire.GCSFilterRegular, []byte("payload")),
 		},
 		{
 			"OnCFHeaders",
@@ -563,7 +564,8 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnCFTypes",
-			wire.NewMsgCFTypes([]uint8{0, 1}),
+			wire.NewMsgCFTypes([]wire.FilterType{
+				wire.GCSFilterRegular, wire.GCSFilterExtended}),
 		},
 		{
 			"OnFeeFilter",

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -821,7 +821,7 @@ func (r FutureGetCFilterResult) Receive() (*wire.MsgCFilter, error) {
 //
 // See GetCFilter for the blocking version and more details.
 func (c *Client) GetCFilterAsync(blockHash *chainhash.Hash,
-	filterType uint8) FutureGetCFilterResult {
+	filterType wire.FilterType) FutureGetCFilterResult {
 	hash := ""
 	if blockHash != nil {
 		hash = blockHash.String()
@@ -833,7 +833,7 @@ func (c *Client) GetCFilterAsync(blockHash *chainhash.Hash,
 
 // GetCFilter returns a raw filter from the server given its block hash.
 func (c *Client) GetCFilter(blockHash *chainhash.Hash,
-	filterType uint8) (*wire.MsgCFilter, error) {
+	filterType wire.FilterType) (*wire.MsgCFilter, error) {
 	return c.GetCFilterAsync(blockHash, filterType).Receive()
 }
 
@@ -878,7 +878,7 @@ func (r FutureGetCFilterHeaderResult) Receive() (*wire.MsgCFHeaders, error) {
 //
 // See GetCFilterHeader for the blocking version and more details.
 func (c *Client) GetCFilterHeaderAsync(blockHash *chainhash.Hash,
-	filterType uint8) FutureGetCFilterHeaderResult {
+	filterType wire.FilterType) FutureGetCFilterHeaderResult {
 	hash := ""
 	if blockHash != nil {
 		hash = blockHash.String()
@@ -891,6 +891,6 @@ func (c *Client) GetCFilterHeaderAsync(blockHash *chainhash.Hash,
 // GetCFilterHeader returns a raw filter header from the server given its block
 // hash.
 func (c *Client) GetCFilterHeader(blockHash *chainhash.Hash,
-	filterType uint8) (*wire.MsgCFHeaders, error) {
+	filterType wire.FilterType) (*wire.MsgCFHeaders, error) {
 	return c.GetCFilterHeaderAsync(blockHash, filterType).Receive()
 }

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -820,19 +820,21 @@ func (r FutureGetCFilterResult) Receive() (*wire.MsgCFilter, error) {
 // returned instance.
 //
 // See GetCFilter for the blocking version and more details.
-func (c *Client) GetCFilterAsync(blockHash *chainhash.Hash, extended bool) FutureGetCFilterResult {
+func (c *Client) GetCFilterAsync(blockHash *chainhash.Hash,
+	filterType uint8) FutureGetCFilterResult {
 	hash := ""
 	if blockHash != nil {
 		hash = blockHash.String()
 	}
 
-	cmd := btcjson.NewGetCFilterCmd(hash, extended)
+	cmd := btcjson.NewGetCFilterCmd(hash, filterType)
 	return c.sendCmd(cmd)
 }
 
 // GetCFilter returns a raw filter from the server given its block hash.
-func (c *Client) GetCFilter(blockHash *chainhash.Hash, extended bool) (*wire.MsgCFilter, error) {
-	return c.GetCFilterAsync(blockHash, extended).Receive()
+func (c *Client) GetCFilter(blockHash *chainhash.Hash,
+	filterType uint8) (*wire.MsgCFilter, error) {
+	return c.GetCFilterAsync(blockHash, filterType).Receive()
 }
 
 // FutureGetCFilterHeaderResult is a future promise to deliver the result of a
@@ -875,18 +877,20 @@ func (r FutureGetCFilterHeaderResult) Receive() (*wire.MsgCFHeaders, error) {
 // on the returned instance.
 //
 // See GetCFilterHeader for the blocking version and more details.
-func (c *Client) GetCFilterHeaderAsync(blockHash *chainhash.Hash, extended bool) FutureGetCFilterHeaderResult {
+func (c *Client) GetCFilterHeaderAsync(blockHash *chainhash.Hash,
+	filterType uint8) FutureGetCFilterHeaderResult {
 	hash := ""
 	if blockHash != nil {
 		hash = blockHash.String()
 	}
 
-	cmd := btcjson.NewGetCFilterHeaderCmd(hash, extended)
+	cmd := btcjson.NewGetCFilterHeaderCmd(hash, filterType)
 	return c.sendCmd(cmd)
 }
 
 // GetCFilterHeader returns a raw filter header from the server given its block
 // hash.
-func (c *Client) GetCFilterHeader(blockHash *chainhash.Hash, extended bool) (*wire.MsgCFHeaders, error) {
-	return c.GetCFilterHeaderAsync(blockHash, extended).Receive()
+func (c *Client) GetCFilterHeader(blockHash *chainhash.Hash,
+	filterType uint8) (*wire.MsgCFHeaders, error) {
+	return c.GetCFilterHeaderAsync(blockHash, filterType).Receive()
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2155,7 +2155,7 @@ func handleGetCFilter(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 		return nil, rpcDecodeHexError(c.Hash)
 	}
 
-	filterBytes, err := s.cfg.CfIndex.FilterByBlockHash(hash, c.Extended)
+	filterBytes, err := s.cfg.CfIndex.FilterByBlockHash(hash, c.FilterType)
 	if err != nil {
 		rpcsLog.Debugf("Could not find committed filter for %v: %v",
 			hash, err)
@@ -2184,7 +2184,7 @@ func handleGetCFilterHeader(s *rpcServer, cmd interface{}, closeChan <-chan stru
 		return nil, rpcDecodeHexError(c.Hash)
 	}
 
-	headerBytes, err := s.cfg.CfIndex.FilterHeaderByBlockHash(hash, c.Extended)
+	headerBytes, err := s.cfg.CfIndex.FilterHeaderByBlockHash(hash, c.FilterType)
 	if len(headerBytes) > 0 {
 		rpcsLog.Debugf("Found header of committed filter for %v", hash)
 	} else {

--- a/server.go
+++ b/server.go
@@ -841,6 +841,18 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 	sp.QueueMessage(headersMsg, nil)
 }
 
+// OnGetCFTypes is invoked when a peer receives a getcftypes bitcoin message.
+func (sp *serverPeer) OnGetCFTypes(_ *peer.Peer, msg *wire.MsgGetCFTypes) {
+	// Ignore getcftypes requests if cfg.NoCFilters is set or we're not in
+	// sync.
+	if cfg.NoCFilters || !sp.server.blockManager.IsCurrent() {
+		return
+	}
+
+	cfTypesMsg := wire.NewMsgCFTypes([]uint8{0, 1})
+	sp.QueueMessage(cfTypesMsg, nil)
+}
+
 // enforceNodeBloomFlag disconnects the peer if the server is not configured to
 // allow bloom filters.  Additionally, if the peer has negotiated to a protocol
 // version  that is high enough to observe the bloom filter service support bit,
@@ -1690,6 +1702,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnGetHeaders:   sp.OnGetHeaders,
 			OnGetCFilter:   sp.OnGetCFilter,
 			OnGetCFHeaders: sp.OnGetCFHeaders,
+			OnGetCFTypes:   sp.OnGetCFTypes,
 			OnFeeFilter:    sp.OnFeeFilter,
 			OnFilterAdd:    sp.OnFilterAdd,
 			OnFilterClear:  sp.OnFilterClear,

--- a/server.go
+++ b/server.go
@@ -849,7 +849,8 @@ func (sp *serverPeer) OnGetCFTypes(_ *peer.Peer, msg *wire.MsgGetCFTypes) {
 		return
 	}
 
-	cfTypesMsg := wire.NewMsgCFTypes([]uint8{0, 1})
+	cfTypesMsg := wire.NewMsgCFTypes([]wire.FilterType{
+		wire.GCSFilterRegular, wire.GCSFilterExtended})
 	sp.QueueMessage(cfTypesMsg, nil)
 }
 

--- a/server.go
+++ b/server.go
@@ -715,7 +715,7 @@ func (sp *serverPeer) OnGetCFilter(_ *peer.Peer, msg *wire.MsgGetCFilter) {
 	}
 
 	filterBytes, err := sp.server.cfIndex.FilterByBlockHash(&msg.BlockHash,
-		msg.Extended)
+		msg.FilterType)
 
 	if len(filterBytes) > 0 {
 		peerLog.Tracef("Obtained CF for %v", msg.BlockHash)
@@ -724,7 +724,7 @@ func (sp *serverPeer) OnGetCFilter(_ *peer.Peer, msg *wire.MsgGetCFilter) {
 			err)
 	}
 
-	filterMsg := wire.NewMsgCFilter(&msg.BlockHash, msg.Extended,
+	filterMsg := wire.NewMsgCFilter(&msg.BlockHash, msg.FilterType,
 		filterBytes)
 	sp.QueueMessage(filterMsg, nil)
 }
@@ -757,7 +757,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		// Fetch the raw committed filter header bytes from the
 		// database.
 		headerBytes, err := sp.server.cfIndex.FilterHeaderByBlockHash(
-			&msg.HashStop, msg.Extended)
+			&msg.HashStop, msg.FilterType)
 		if (err != nil) || (len(headerBytes) == 0) {
 			peerLog.Warnf("Could not obtain CF header for %v: %v",
 				msg.HashStop, err)
@@ -776,7 +776,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		headersMsg := wire.NewMsgCFHeaders()
 		headersMsg.AddCFHeader(&header)
 		headersMsg.StopHash = msg.HashStop
-		headersMsg.Extended = msg.Extended
+		headersMsg.FilterType = msg.FilterType
 		sp.QueueMessage(headersMsg, nil)
 		return
 	}
@@ -817,7 +817,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		// Fetch the raw committed filter header bytes from the
 		// database.
 		headerBytes, err := sp.server.cfIndex.FilterHeaderByBlockHash(
-			&hashList[i], msg.Extended)
+			&hashList[i], msg.FilterType)
 		if (err != nil) || (len(headerBytes) == 0) {
 			peerLog.Warnf("Could not obtain CF header for %v: %v",
 				hashList[i], err)
@@ -836,7 +836,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		headersMsg.AddCFHeader(&header)
 	}
 
-	headersMsg.Extended = msg.Extended
+	headersMsg.FilterType = msg.FilterType
 	headersMsg.StopHash = hashList[len(hashList)-1]
 	sp.QueueMessage(headersMsg, nil)
 }

--- a/server.go
+++ b/server.go
@@ -849,6 +849,8 @@ func (sp *serverPeer) OnGetCFTypes(_ *peer.Peer, msg *wire.MsgGetCFTypes) {
 		return
 	}
 
+	// TODO: update to query blockchain indexes and/or config for supported
+	// filter types.
 	cfTypesMsg := wire.NewMsgCFTypes([]wire.FilterType{
 		wire.GCSFilterRegular, wire.GCSFilterExtended})
 	sp.QueueMessage(cfTypesMsg, nil)

--- a/wire/message.go
+++ b/wire/message.go
@@ -53,8 +53,10 @@ const (
 	CmdFeeFilter    = "feefilter"
 	CmdGetCFilter   = "getcfilter"
 	CmdGetCFHeaders = "getcfheaders"
+	CmdGetCFTypes   = "getcftypes"
 	CmdCFilter      = "cfilter"
 	CmdCFHeaders    = "cfheaders"
+	CmdCFTypes      = "cftypes"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -166,11 +168,17 @@ func makeEmptyMessage(command string) (Message, error) {
 	case CmdGetCFHeaders:
 		msg = &MsgGetCFHeaders{}
 
+	case CmdGetCFTypes:
+		msg = &MsgGetCFTypes{}
+
 	case CmdCFilter:
 		msg = &MsgCFilter{}
 
 	case CmdCFHeaders:
 		msg = &MsgCFHeaders{}
+
+	case CmdCFTypes:
+		msg = &MsgCFTypes{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -71,8 +71,10 @@ func TestMessage(t *testing.T) {
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
 	msgGetCFilter := NewMsgGetCFilter(&chainhash.Hash{}, 0)
 	msgGetCFHeaders := NewMsgGetCFHeaders()
+	msgGetCFTypes := NewMsgGetCFTypes()
 	msgCFilter := NewMsgCFilter(&chainhash.Hash{}, 1, []byte("payload"))
 	msgCFHeaders := NewMsgCFHeaders()
+	msgCFTypes := NewMsgCFTypes([]uint8{2})
 
 	tests := []struct {
 		in     Message    // Value to encode
@@ -104,8 +106,10 @@ func TestMessage(t *testing.T) {
 		{msgReject, msgReject, pver, MainNet, 79},
 		{msgGetCFilter, msgGetCFilter, pver, MainNet, 57},
 		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 62},
+		{msgGetCFTypes, msgGetCFTypes, pver, MainNet, 24},
 		{msgCFilter, msgCFilter, pver, MainNet, 65},
 		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},
+		{msgCFTypes, msgCFTypes, pver, MainNet, 26},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -69,12 +69,13 @@ func TestMessage(t *testing.T) {
 	bh := NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0)
 	msgMerkleBlock := NewMsgMerkleBlock(bh)
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
-	msgGetCFilter := NewMsgGetCFilter(&chainhash.Hash{}, 0)
+	msgGetCFilter := NewMsgGetCFilter(&chainhash.Hash{}, GCSFilterExtended)
 	msgGetCFHeaders := NewMsgGetCFHeaders()
 	msgGetCFTypes := NewMsgGetCFTypes()
-	msgCFilter := NewMsgCFilter(&chainhash.Hash{}, 1, []byte("payload"))
+	msgCFilter := NewMsgCFilter(&chainhash.Hash{}, GCSFilterExtended,
+		[]byte("payload"))
 	msgCFHeaders := NewMsgCFHeaders()
-	msgCFTypes := NewMsgCFTypes([]uint8{2})
+	msgCFTypes := NewMsgCFTypes([]FilterType{GCSFilterExtended})
 
 	tests := []struct {
 		in     Message    // Value to encode

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -105,7 +105,7 @@ func TestMessage(t *testing.T) {
 		{msgMerkleBlock, msgMerkleBlock, pver, MainNet, 110},
 		{msgReject, msgReject, pver, MainNet, 79},
 		{msgGetCFilter, msgGetCFilter, pver, MainNet, 57},
-		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 62},
+		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 58},
 		{msgGetCFTypes, msgGetCFTypes, pver, MainNet, 24},
 		{msgCFilter, msgCFilter, pver, MainNet, 65},
 		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
 // makeHeader is a convenience function to make a message header in the form of
@@ -69,9 +69,9 @@ func TestMessage(t *testing.T) {
 	bh := NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0)
 	msgMerkleBlock := NewMsgMerkleBlock(bh)
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
-	msgGetCFilter := NewMsgGetCFilter(&chainhash.Hash{}, false)
+	msgGetCFilter := NewMsgGetCFilter(&chainhash.Hash{}, 0)
 	msgGetCFHeaders := NewMsgGetCFHeaders()
-	msgCFilter := NewMsgCFilter(&chainhash.Hash{}, true, []byte("payload"))
+	msgCFilter := NewMsgCFilter(&chainhash.Hash{}, 1, []byte("payload"))
 	msgCFHeaders := NewMsgCFHeaders()
 
 	tests := []struct {

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -28,7 +28,7 @@ const (
 // MsgGetCFHeaders for details on requesting the headers.
 type MsgCFHeaders struct {
 	StopHash     chainhash.Hash
-	FilterType   uint8
+	FilterType   FilterType
 	HeaderHashes []*chainhash.Hash
 }
 

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -150,9 +150,10 @@ func (msg *MsgCFHeaders) Command() string {
 }
 
 // MaxPayloadLength returns the maximum length the payload can be for the
-// receiver.  This is part of the Message interface implementation.
+// receiver. This is part of the Message interface implementation.
 func (msg *MsgCFHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Hash size + num headers (varInt) + (header size * max headers).
+	// Hash size + filter type + num headers (varInt) +
+	// (header size * max headers).
 	return chainhash.HashSize + 1 + MaxVarIntPayload +
 		(MaxCFHeaderPayload * MaxCFHeadersPerMsg)
 }

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -28,7 +28,7 @@ const (
 // MsgGetCFHeaders for details on requesting the headers.
 type MsgCFHeaders struct {
 	StopHash     chainhash.Hash
-	Extended     bool
+	FilterType   uint8
 	HeaderHashes []*chainhash.Hash
 }
 
@@ -53,8 +53,8 @@ func (msg *MsgCFHeaders) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) 
 		return err
 	}
 
-	// Read extended flag
-	err = readElement(r, &msg.Extended)
+	// Read filter type
+	err = readElement(r, &msg.FilterType)
 	if err != nil {
 		return err
 	}
@@ -97,8 +97,8 @@ func (msg *MsgCFHeaders) BtcEncode(w io.Writer, pver uint32, _ MessageEncoding) 
 		return err
 	}
 
-	// Write extended flag
-	err = writeElement(w, msg.Extended)
+	// Write filter type
+	err = writeElement(w, msg.FilterType)
 	if err != nil {
 		return err
 	}

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -17,9 +17,9 @@ const (
 )
 
 type MsgCFilter struct {
-	BlockHash chainhash.Hash
-	Extended  bool
-	Data      []byte
+	BlockHash  chainhash.Hash
+	FilterType uint8
+	Data       []byte
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
@@ -31,8 +31,8 @@ func (msg *MsgCFilter) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) er
 	if err != nil {
 		return err
 	}
-	// Read extended flag
-	err = readElement(r, &msg.Extended)
+	// Read filter type
+	err = readElement(r, &msg.FilterType)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (msg *MsgCFilter) BtcEncode(w io.Writer, pver uint32, _ MessageEncoding) er
 		return err
 	}
 
-	err = writeElement(w, msg.Extended)
+	err = writeElement(w, msg.FilterType)
 	if err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func (msg *MsgCFilter) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgCFilter returns a new bitcoin cfilter message that conforms to the
 // Message interface. See MsgCFilter for details.
-func NewMsgCFilter(blockHash *chainhash.Hash, extended bool,
+func NewMsgCFilter(blockHash *chainhash.Hash, filterType uint8,
 	data []byte) *MsgCFilter {
 	return &MsgCFilter{
-		BlockHash: *blockHash,
-		Extended:  extended,
-		Data:      data,
+		BlockHash:  *blockHash,
+		FilterType: filterType,
+		Data:       data,
 	}
 }

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -13,9 +13,13 @@ import (
 
 const (
 	// MaxCFilterDataSize is the maximum byte size of a committed filter.
-	MaxCFilterDataSize = 262144
+	// The maximum size is currently defined as 256KiB.
+	MaxCFilterDataSize = 256 * 1024
 )
 
+// MsgCFilter implements the Message interface and represents a bitcoin cfilter
+// message. It is used to deliver a committed filter in response to a
+// getcfilter (MsgGetCFilter) message.
 type MsgCFilter struct {
 	BlockHash  chainhash.Hash
 	FilterType uint8
@@ -25,9 +29,8 @@ type MsgCFilter struct {
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgCFilter) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
-	var err error
 	// Read the hash of the filter's block
-	err = readElement(r, &msg.BlockHash)
+	err := readElement(r, &msg.BlockHash)
 	if err != nil {
 		return err
 	}

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -22,7 +22,7 @@ const (
 // getcfilter (MsgGetCFilter) message.
 type MsgCFilter struct {
 	BlockHash  chainhash.Hash
-	FilterType uint8
+	FilterType FilterType
 	Data       []byte
 }
 
@@ -99,7 +99,7 @@ func (msg *MsgCFilter) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgCFilter returns a new bitcoin cfilter message that conforms to the
 // Message interface. See MsgCFilter for details.
-func NewMsgCFilter(blockHash *chainhash.Hash, filterType uint8,
+func NewMsgCFilter(blockHash *chainhash.Hash, filterType FilterType,
 	data []byte) *MsgCFilter {
 	return &MsgCFilter{
 		BlockHash:  *blockHash,

--- a/wire/msgcftypes.go
+++ b/wire/msgcftypes.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import "io"
+
+// MsgCFTypes is the cftypes message.
+type MsgCFTypes struct {
+	NumFilters       uint8
+	SupportedFilters []uint8
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgCFTypes) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
+	// Read the number of filter types supported
+	err := readElement(r, &msg.NumFilters)
+	if err != nil {
+		return err
+	}
+
+	// Read each filter type.
+	msg.SupportedFilters = make([]uint8, msg.NumFilters)
+	for i := uint8(0); i < msg.NumFilters; i++ {
+		err = readElement(r, &msg.SupportedFilters[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgCFTypes) BtcEncode(w io.Writer, pver uint32, _ MessageEncoding) error {
+	// Write length of supported filters slice; don't trust that the caller
+	// has set it correctly.
+	err := writeElement(w, uint8(len(msg.SupportedFilters)))
+	if err != nil {
+		return err
+	}
+
+	for i := range msg.SupportedFilters {
+		err = writeElement(w, msg.SupportedFilters[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Deserialize decodes a filter from r into the receiver using a format that is
+// suitable for long-term storage such as a database. This function differs
+// from BtcDecode in that BtcDecode decodes from the bitcoin wire protocol as
+// it was sent across the network.  The wire encoding can technically differ
+// depending on the protocol version and doesn't even really need to match the
+// format of a stored filter at all. As of the time this comment was written,
+// the encoded filter is the same in both instances, but there is a distinct
+// difference and separating the two allows the API to be flexible enough to
+// deal with changes.
+func (msg *MsgCFTypes) Deserialize(r io.Reader) error {
+	// At the current time, there is no difference between the wire encoding
+	// and the stable long-term storage format.  As a result, make use of
+	// BtcDecode.
+	return msg.BtcDecode(r, 0, BaseEncoding)
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgCFTypes) Command() string {
+	return CmdCFTypes
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgCFTypes) MaxPayloadLength(pver uint32) uint32 {
+	// 1 byte for NumFilters, and 1 byte for up to 255 filter types.
+	return 256
+}
+
+// NewMsgCFTypes returns a new bitcoin cftypes message that conforms to the
+// Message interface. See MsgCFTypes for details.
+func NewMsgCFTypes(filterTypes []uint8) *MsgCFTypes {
+	return &MsgCFTypes{
+		NumFilters:       uint8(len(filterTypes)),
+		SupportedFilters: filterTypes,
+	}
+}

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -17,7 +17,7 @@ import (
 type MsgGetCFHeaders struct {
 	BlockLocatorHashes []*chainhash.Hash
 	HashStop           chainhash.Hash
-	FilterType         uint8
+	FilterType         FilterType
 }
 
 // AddBlockLocatorHash adds a new block locator hash to the message.

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -15,7 +15,6 @@ import (
 // filter headers. It allows to set the FilterType field to get headers in the
 // chain of basic (0x00) or extended (0x01) headers.
 type MsgGetCFHeaders struct {
-	ProtocolVersion    uint32
 	BlockLocatorHashes []*chainhash.Hash
 	HashStop           chainhash.Hash
 	FilterType         uint8
@@ -36,11 +35,6 @@ func (msg *MsgGetCFHeaders) AddBlockLocatorHash(hash *chainhash.Hash) error {
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgGetCFHeaders) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
-	err := readElement(r, &msg.ProtocolVersion)
-	if err != nil {
-		return err
-	}
-
 	// Read num block locator hashes and limit to max.
 	count, err := ReadVarInt(r, pver)
 	if err != nil {
@@ -84,12 +78,7 @@ func (msg *MsgGetCFHeaders) BtcEncode(w io.Writer, pver uint32, _ MessageEncodin
 		return messageError("MsgGetHeaders.BtcEncode", str)
 	}
 
-	err := writeElement(w, msg.ProtocolVersion)
-	if err != nil {
-		return err
-	}
-
-	err = WriteVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}
@@ -118,9 +107,9 @@ func (msg *MsgGetCFHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Version 4 bytes + num block locator hashes (varInt) + max allowed
+	// Num block locator hashes (varInt) + max allowed
 	// block locators + hash stop + filter type 1 byte.
-	return 4 + MaxVarIntPayload + (MaxBlockLocatorsPerMsg *
+	return MaxVarIntPayload + (MaxBlockLocatorsPerMsg *
 		chainhash.HashSize) + chainhash.HashSize + 1
 }
 

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -12,13 +12,13 @@ import (
 )
 
 // MsgGetCFHeaders is a message similar to MsgGetHeaders, but for committed
-// filter headers. It allows to set the Extended field to get headers in the
-// chain of basic (false) or extended (true) headers.
+// filter headers. It allows to set the FilterType field to get headers in the
+// chain of basic (0x00) or extended (0x01) headers.
 type MsgGetCFHeaders struct {
 	ProtocolVersion    uint32
 	BlockLocatorHashes []*chainhash.Hash
 	HashStop           chainhash.Hash
-	Extended           bool
+	FilterType         uint8
 }
 
 // AddBlockLocatorHash adds a new block locator hash to the message.
@@ -70,7 +70,7 @@ func (msg *MsgGetCFHeaders) BtcDecode(r io.Reader, pver uint32, _ MessageEncodin
 		return err
 	}
 
-	return readElement(r, &msg.Extended)
+	return readElement(r, &msg.FilterType)
 }
 
 // BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
@@ -106,7 +106,7 @@ func (msg *MsgGetCFHeaders) BtcEncode(w io.Writer, pver uint32, _ MessageEncodin
 		return err
 	}
 
-	return writeElement(w, msg.Extended)
+	return writeElement(w, msg.FilterType)
 }
 
 // Command returns the protocol command string for the message.  This is part
@@ -119,7 +119,7 @@ func (msg *MsgGetCFHeaders) Command() string {
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFHeaders) MaxPayloadLength(pver uint32) uint32 {
 	// Version 4 bytes + num block locator hashes (varInt) + max allowed
-	// block locators + hash stop + Extended flag 1 byte.
+	// block locators + hash stop + filter type 1 byte.
 	return 4 + MaxVarIntPayload + (MaxBlockLocatorsPerMsg *
 		chainhash.HashSize) + chainhash.HashSize + 1
 }

--- a/wire/msggetcfilter.go
+++ b/wire/msggetcfilter.go
@@ -11,8 +11,8 @@ import (
 )
 
 type MsgGetCFilter struct {
-	BlockHash chainhash.Hash
-	Extended  bool
+	BlockHash  chainhash.Hash
+	FilterType uint8
 }
 
 func (msg *MsgGetCFilter) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
@@ -20,7 +20,7 @@ func (msg *MsgGetCFilter) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding)
 	if err != nil {
 		return err
 	}
-	return readElement(r, &msg.Extended)
+	return readElement(r, &msg.FilterType)
 }
 
 // BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
@@ -30,7 +30,7 @@ func (msg *MsgGetCFilter) BtcEncode(w io.Writer, pver uint32, _ MessageEncoding)
 	if err != nil {
 		return err
 	}
-	return writeElement(w, msg.Extended)
+	return writeElement(w, msg.FilterType)
 }
 
 // Command returns the protocol command string for the message.  This is part
@@ -42,16 +42,16 @@ func (msg *MsgGetCFilter) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFilter) MaxPayloadLength(pver uint32) uint32 {
-	// Block hash + Extended flag.
+	// Block hash + filter type.
 	return chainhash.HashSize + 1
 }
 
 // NewMsgGetCFilter returns a new bitcoin getcfilter message that conforms to
 // the Message interface using the passed parameters and defaults for the
 // remaining fields.
-func NewMsgGetCFilter(blockHash *chainhash.Hash, extended bool) *MsgGetCFilter {
+func NewMsgGetCFilter(blockHash *chainhash.Hash, filterType uint8) *MsgGetCFilter {
 	return &MsgGetCFilter{
-		BlockHash: *blockHash,
-		Extended:  extended,
+		BlockHash:  *blockHash,
+		FilterType: filterType,
 	}
 }

--- a/wire/msggetcfilter.go
+++ b/wire/msggetcfilter.go
@@ -14,7 +14,7 @@ import (
 // getcfilter message. It is used to request a committed filter for a block.
 type MsgGetCFilter struct {
 	BlockHash  chainhash.Hash
-	FilterType uint8
+	FilterType FilterType
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
@@ -53,7 +53,8 @@ func (msg *MsgGetCFilter) MaxPayloadLength(pver uint32) uint32 {
 // NewMsgGetCFilter returns a new bitcoin getcfilter message that conforms to
 // the Message interface using the passed parameters and defaults for the
 // remaining fields.
-func NewMsgGetCFilter(blockHash *chainhash.Hash, filterType uint8) *MsgGetCFilter {
+func NewMsgGetCFilter(blockHash *chainhash.Hash,
+	filterType FilterType) *MsgGetCFilter {
 	return &MsgGetCFilter{
 		BlockHash:  *blockHash,
 		FilterType: filterType,

--- a/wire/msggetcfilter.go
+++ b/wire/msggetcfilter.go
@@ -10,11 +10,15 @@ import (
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
+// MsgGetCFilter implements the Message interface and represents a bitcoin
+// getcfilter message. It is used to request a committed filter for a block.
 type MsgGetCFilter struct {
 	BlockHash  chainhash.Hash
 	FilterType uint8
 }
 
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
 func (msg *MsgGetCFilter) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
 	err := readElement(r, &msg.BlockHash)
 	if err != nil {

--- a/wire/msggetcftypes.go
+++ b/wire/msggetcftypes.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import "io"
+
+// MsgGetCFTypes is the getcftypes message.
+type MsgGetCFTypes struct {
+}
+
+// BtcDecode decodes the receiver from w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetCFTypes) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetCFTypes) BtcEncode(w io.Writer, pver uint32, _ MessageEncoding) error {
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgGetCFTypes) Command() string {
+	return CmdGetCFTypes
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgGetCFTypes) MaxPayloadLength(pver uint32) uint32 {
+	// Empty message.
+	return 0
+}
+
+// NewMsgGetCFTypes returns a new bitcoin getcftypes message that conforms to
+// the Message interface.
+func NewMsgGetCFTypes() *MsgGetCFTypes {
+	return &MsgGetCFTypes{}
+}

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -72,9 +72,20 @@ const (
 	// and transactions including witness data (BIP0144).
 	SFNodeWitness
 
+	// SFNodeXthin is a flag used to indicate a peer supports xthin blocks.
+	SFNodeXthin
+
+	// SFNodeBit5 is a flag used to indicate a peer supports a service
+	// defined by bit 5.
+	SFNodeBit5
+
 	// SFNodeCF is a flag used to indicate a peer supports committed
 	// filters (CFs).
 	SFNodeCF
+
+	// SFNode2X is a flag used to indicate a peer is running the Segwit2X
+	// software.
+	SFNode2X
 )
 
 // Map of service flags back to their constant names for pretty printing.
@@ -83,7 +94,10 @@ var sfStrings = map[ServiceFlag]string{
 	SFNodeGetUTXO: "SFNodeGetUTXO",
 	SFNodeBloom:   "SFNodeBloom",
 	SFNodeWitness: "SFNodeWitness",
+	SFNodeXthin:   "SFNodeXthin",
+	SFNodeBit5:    "SFNodeBit5",
 	SFNodeCF:      "SFNodeCF",
+	SFNode2X:      "SFNode2X",
 }
 
 // orderedSFStrings is an ordered list of service flags from highest to
@@ -93,7 +107,10 @@ var orderedSFStrings = []ServiceFlag{
 	SFNodeGetUTXO,
 	SFNodeBloom,
 	SFNodeWitness,
+	SFNodeXthin,
+	SFNodeBit5,
 	SFNodeCF,
+	SFNode2X,
 }
 
 // String returns the ServiceFlag in human-readable form.

--- a/wire/protocol_test.go
+++ b/wire/protocol_test.go
@@ -17,8 +17,11 @@ func TestServiceFlagStringer(t *testing.T) {
 		{SFNodeGetUTXO, "SFNodeGetUTXO"},
 		{SFNodeBloom, "SFNodeBloom"},
 		{SFNodeWitness, "SFNodeWitness"},
+		{SFNodeXthin, "SFNodeXthin"},
+		{SFNodeBit5, "SFNodeBit5"},
 		{SFNodeCF, "SFNodeCF"},
-		{0xffffffff, "SFNodeNetwork|SFNodeGetUTXO|SFNodeBloom|SFNodeWitness|SFNodeCF|0xffffffe0"},
+		{SFNode2X, "SFNode2X"},
+		{0xffffffff, "SFNodeNetwork|SFNodeGetUTXO|SFNodeBloom|SFNodeWitness|SFNodeXthin|SFNodeBit5|SFNodeCF|SFNode2X|0xffffff00"},
 	}
 
 	t.Logf("Running %d tests", len(tests))


### PR DESCRIPTION
This update adds the `cftypes` and `getcftypes` messages, as well as making all of the other cfilter-related messages use a `uint8` filter type rather than a `bool` for "extended" vs. "regular" filters. It also changes the service bit from 4 (conflicts with Xthin) to 6, which seems to have very few nodes advertising it on both mainnet and testnet.