### PR TITLE
rpcclient: SendRawTransaction error codes

### DIFF
--- a/mempool/error.go
+++ b/mempool/error.go
@@ -5,6 +5,8 @@
 package mempool
 
 import (
+	"fmt"
+
 	"github.com/roasbeef/btcd/blockchain"
 	"github.com/roasbeef/btcd/wire"
 )
@@ -39,7 +41,7 @@ type TxRuleError struct {
 
 // Error satisfies the error interface and prints human-readable errors.
 func (e TxRuleError) Error() string {
-	return e.Description
+	return fmt.Sprintf("%s (RejectCode: %d)", e.Description, e.RejectCode)
 }
 
 // txRuleError creates an underlying TxRuleError with the given a set of


### PR DESCRIPTION
This PR adds a new error type `SendRawTransactionRejectError` that is returned from the `SendRawTransaction` command in case the `JSON` error we receive from the RPC server contains a well know `RejectCode`. It is used to wrap this reject code, such that callers more easily can inspect the reason for rejection.

TODO:
- [ ] `bitcoind` compatability?