### PR TITLE
Fee estimation fixes

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -45,7 +45,7 @@ const (
 	// it will provide fee estimations.
 	DefaultEstimateFeeMinRegisteredBlocks = 3
 
-	bytePerKb = 1024
+	bytePerKb = 1000
 
 	btcPerSatoshi = 1E-8
 )

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -527,7 +527,7 @@ func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint, tx *btcutil
 			Added:    time.Now(),
 			Height:   height,
 			Fee:      fee,
-			FeePerKB: fee * 1000 / int64(tx.MsgTx().SerializeSize()),
+			FeePerKB: fee * 1000 / GetTxVirtualSize(tx),
 		},
 		StartingPriority: mining.CalcPriority(tx.MsgTx(), utxoView, height),
 	}


### PR DESCRIPTION
This PR makes sure the fee rate is calculated consistently in the fee estimator, and that `feePerKB` is based on `vsize` instead of legacy `size`.