### PR TITLE
rpcclient: expose the Node command for RPC API.

### DIFF
--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -63,6 +63,40 @@ func (c *Client) AddNode(host string, command AddNodeCommand) error {
 	return c.AddNodeAsync(host, command).Receive()
 }
 
+// FutureNodeResult is a future promise to deliver the result of an NodeAsync
+// RPC invocation (or an applicable error).
+type FutureNodeResult chan *response
+
+// Receive waits for the response promised by the future and returns an error if
+// any occurred when performing the specified command.
+func (r FutureNodeResult) Receive() error {
+	_, err := receiveFuture(r)
+	return err
+}
+
+// NodeAsync returns an instance of a type that can be used to get the result
+// of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See Node for the blocking version and more details.
+func (c *Client) NodeAsync(command btcjson.NodeSubCmd, host string,
+	connectSubCmd *string) FutureNodeResult {
+	cmd := btcjson.NewNodeCmd(command, host, connectSubCmd)
+	return c.sendCmd(cmd)
+}
+
+// Node attempts to perform the passed node command on the host.
+// For example, it can be used to add or a remove a persistent peer, or to do
+// connect or diconnect a non-persistent one.
+//
+// The connectSubCmd should be set either "perm" or "temp", depending on
+// whether we are targetting a persistent or non-persistent peer. Passing nil
+// will cause the default value to be used.
+func (c *Client) Node(command btcjson.NodeSubCmd, host string,
+	connectSubCmd *string) error {
+	return c.NodeAsync(command, host, connectSubCmd).Receive()
+}
+
 // FutureGetAddedNodeInfoResult is a future promise to deliver the result of a
 // GetAddedNodeInfoAsync RPC invocation (or an applicable error).
 type FutureGetAddedNodeInfoResult chan *response


### PR DESCRIPTION
The `AddNode` command is not particularly easy to use for managing connections, this PR exposes the more useful `Node` command for the `rpcclient`.